### PR TITLE
Fixed prop validation for "to"

### DIFF
--- a/src/NavTab.js
+++ b/src/NavTab.js
@@ -60,7 +60,10 @@ export const NavTab = ({
 };
 
 NavTab.propTypes = {
-  to: PropTypes.string.isRequired,
+  to: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object
+  ]).isRequired,
   replace: PropTypes.bool,
   exact: PropTypes.bool,
   strict: PropTypes.bool,


### PR DESCRIPTION
Because the prop 'to' can accept object also.

For example, I might use NavTab to relay the search part of the URL, like so:
`<NavTab to={{pathname:'some/path', search:this.props.location.search}}>Beam me up!</NavTab>`

Such a case should not give a propType warning.